### PR TITLE
Fix HTML attributes and update SpotlightCard rendering

### DIFF
--- a/skywalker-quest-map/skywalker_quest_map_guide.html
+++ b/skywalker-quest-map/skywalker_quest_map_guide.html
@@ -441,7 +441,6 @@ This guide ends, but your myth continues. Just as Luke's story ripples beyond <e
       <script type="text/babel">
         'use strict';
 
-'use strict';
 
 // 1. Define the GENERALIZED React Component
 function CollapsibleSection(props) {

--- a/skywalker-quest-map/testing/css_test_document.html
+++ b/skywalker-quest-map/testing/css_test_document.html
@@ -106,7 +106,7 @@ Welcome to the beginning of your journey. This stage is not about action—it is
 </ol>
 
 <div class="tiered-questions">
-    <SpotlightCard className="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
+    <SpotlightCard class="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
         <div class="question-level">
             <h3>Level 1 – Pathfinder</h3>
             <ul>
@@ -116,7 +116,7 @@ Welcome to the beginning of your journey. This stage is not about action—it is
         </div>
     </SpotlightCard>
     
-    <SpotlightCard className="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
+    <SpotlightCard class="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
         <div class="question-level">
             <h3>Level 2 – Wayfinder</h3>
             <ul>
@@ -126,7 +126,7 @@ Welcome to the beginning of your journey. This stage is not about action—it is
         </div>
     </SpotlightCard>
     
-    <SpotlightCard className="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
+    <SpotlightCard class="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
         <div class="question-level">
             <h3>Level 3 – Trailblazer</h3>
             <ul>
@@ -182,7 +182,7 @@ This stage is about movement—external and internal. When the world as you know
 <li>Identify your mentors—guides who challenge and support your growth.</li>
 </ol>
 <div class="tiered-questions">
-    <SpotlightCard className="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
+    <SpotlightCard class="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
         <div class="question-level">
             <h3>Level 1 – Pathfinder</h3>
             <ul>
@@ -192,7 +192,7 @@ This stage is about movement—external and internal. When the world as you know
         </div>
     </SpotlightCard>
     
-    <SpotlightCard className="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
+    <SpotlightCard class="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
         <div class="question-level">
             <h3>Level 2 – Wayfinder</h3>
             <ul>
@@ -202,7 +202,7 @@ This stage is about movement—external and internal. When the world as you know
         </div>
     </SpotlightCard>
     
-    <SpotlightCard className="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
+    <SpotlightCard class="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
         <div class="question-level">
             <h3>Level 3 – Trailblazer</h3>
             <ul>
@@ -272,7 +272,7 @@ This is the crossroads. Action has begun, but purpose is not yet formed. You are
 <li>Reflect on a time when loss triggered growth.</li>
 </ol>
 <div class="tiered-questions">
-    <SpotlightCard className="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
+    <SpotlightCard class="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
         <div class="question-level">
             <h3>Level 1 – Pathfinder</h3>
             <ul>
@@ -282,7 +282,7 @@ This is the crossroads. Action has begun, but purpose is not yet formed. You are
         </div>
     </SpotlightCard>
     
-    <SpotlightCard className="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
+    <SpotlightCard class="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
         <div class="question-level">
             <h3>Level 2 – Wayfinder</h3>
             <ul>
@@ -292,7 +292,7 @@ This is the crossroads. Action has begun, but purpose is not yet formed. You are
         </div>
     </SpotlightCard>
     
-    <SpotlightCard className="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
+    <SpotlightCard class="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
         <div class="question-level">
             <h3>Level 3 – Trailblazer</h3>
             <ul>
@@ -362,7 +362,7 @@ This is the deep shadow work of the quest. You must now look within—at the par
 <li>Confront your inherited patterns and how they shape your choices.</li>
 </ol>
 <div class="tiered-questions">
-    <SpotlightCard className="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
+    <SpotlightCard class="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
         <div class="question-level">
             <h3>Level 1 – Pathfinder</h3>
             <ul>
@@ -372,7 +372,7 @@ This is the deep shadow work of the quest. You must now look within—at the par
         </div>
     </SpotlightCard>
     
-    <SpotlightCard className="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
+    <SpotlightCard class="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
         <div class="question-level">
             <h3>Level 2 – Wayfinder</h3>
             <ul>
@@ -382,7 +382,7 @@ This is the deep shadow work of the quest. You must now look within—at the par
         </div>
     </SpotlightCard>
     
-    <SpotlightCard className="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
+    <SpotlightCard class="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
         <div class="question-level">
             <h3>Level 3 – Trailblazer</h3>
             <ul>
@@ -452,7 +452,7 @@ This final stage is not an end, but a return to self—transformed. What have yo
 <li>Commit to sharing what you’ve learned—with self, others, and the world.</li>
 </ol>
 <div class="tiered-questions">
-    <SpotlightCard className="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
+    <SpotlightCard class="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
         <div class="question-level">
             <h3>Level 1 – Pathfinder</h3>
             <ul>
@@ -462,7 +462,7 @@ This final stage is not an end, but a return to self—transformed. What have yo
         </div>
     </SpotlightCard>
     
-    <SpotlightCard className="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
+    <SpotlightCard class="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
         <div class="question-level">
             <h3>Level 2 – Wayfinder</h3>
             <ul>
@@ -472,7 +472,7 @@ This final stage is not an end, but a return to self—transformed. What have yo
         </div>
     </SpotlightCard>
     
-    <SpotlightCard className="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
+    <SpotlightCard class="custom-spotlight-card" spotlightColor="rgba(0, 229, 255, 0.2)">
         <div class="question-level">
             <h3>Level 3 – Trailblazer</h3>
             <ul>

--- a/skywalker-quest-map/testing/render_spotlight_cards.js
+++ b/skywalker-quest-map/testing/render_spotlight_cards.js
@@ -13,10 +13,11 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // Find all elements with the tag name 'SpotlightCard'
   const spotlightCardElements = document.querySelectorAll('SpotlightCard');
-  
+
   spotlightCardElements.forEach((element, index) => {
     // Extract attributes
-    const className = element.getAttribute('className') || '';
+    const className =
+      element.getAttribute('class') || element.getAttribute('className') || '';
     const spotlightColor = element.getAttribute('spotlightColor') || 'rgba(255, 255, 255, 0.25)';
 
     // Get the inner HTML as children
@@ -35,7 +36,8 @@ document.addEventListener("DOMContentLoaded", function () {
       React.createElement('div', { dangerouslySetInnerHTML: { __html: children } })
     );
 
-    ReactDOM.render(reactElement, wrapper);
+    const root = ReactDOM.createRoot(wrapper);
+    root.render(reactElement);
     console.log(`Rendered SpotlightCard ${index + 1} of ${spotlightCardElements.length}`);
   });
 });


### PR DESCRIPTION
## Summary
- switch SpotlightCard tags to use `class` instead of `className`
- allow both `class` and `className` in render script
- use `ReactDOM.createRoot` when rendering SpotlightCard components
- remove duplicate `'use strict'` line in guide

## Testing
- `node -e "require('./skywalker-quest-map/testing/render_spotlight_cards.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68556ccc2da483238e6036ea09a58c7f