### PR TITLE
Add dual MIT and CC BY-NC-ND license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,46 @@
+# License
+
+## Code
+
+Copyright (c) 2025 Ben Wassa (GitHub: benwassa)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Content
+
+The text, audio, images, and other creative content in this project are
+licensed under the Creative Commons Attribution-NonCommercial-NoDerivatives
+4.0 International license (CC BY-NC-ND 4.0). See
+<https://creativecommons.org/licenses/by-nc-nd/4.0/> for the complete terms.
+
+### Allowed
+- Sharing the material in any medium or format with attribution for
+  non-commercial purposes.
+
+### Not Allowed
+- Commercial use of the content.
+- Distribution of derivative or remixed versions of the content.
+
+### Attribution
+Please credit: Ben Wassa (GitHub: benwassa)
+
+## Summary
+- Code: MIT License
+- Content: CC BY-NC-ND 4.0, non-commercial and no derivatives
+- Attribution required for any sharing


### PR DESCRIPTION
## Summary
- establish licensing policy with MIT terms for code and CC BY-NC-ND 4.0 for content
- document attribution requirements and usage limitations

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bac366fc8323a223568f90319b34